### PR TITLE
Closes #152; Side bar too long

### DIFF
--- a/theme/shippable/static/ash/css/custom.css
+++ b/theme/shippable/static/ash/css/custom.css
@@ -291,6 +291,8 @@ code {
   padding: 10px;
   padding-right: 0px;
   z-index: 10;
+  max-height: 50%;
+  overflow-y: scroll;
 }
 
 #sidebar .tocbar.stick {


### PR DESCRIPTION
Closes #152 

<img width="310" alt="screenshot 2015-08-25 15 23 17" src="https://cloud.githubusercontent.com/assets/5751414/9481303/e0ac9cd4-4b3d-11e5-8ba1-dd27955898ce.png">
<img width="316" alt="screenshot 2015-08-25 15 26 30" src="https://cloud.githubusercontent.com/assets/5751414/9481304/e0babdaa-4b3d-11e5-85ac-579efbec91c5.png">
