### PR TITLE
Added shippable.yml examples for key integrations

### DIFF
--- a/sources/int_keys.md
+++ b/sources/int_keys.md
@@ -18,7 +18,17 @@ To create an account integration for an SSH key, do the following:
 - Enter a name for your key and then click on the `Generate keys` button. This will generate an SSH key for your account.
 - `Save` the generated key.
 
-You will need to add this key to the Settings of every project you want to use it in. Your SSH key will then be available in your build minion and you can use ssh commands in your shippable.yml.
+You will need to add this key to both the Settings **and** the shippable.yml of every project you want to use it in. Example shippable.yml integration:
+```yaml
+integrations:
+   key:
+      - integrationName: MySSHKeyIntegration
+        type: ssh-key
+```
+ * `integrationName` is the name of the SSH integration you added to the project settings.
+ * `type` is ssh-key
+
+Your SSH key will be available on your build minion in the `/tmp/ssh/` directory. You can then use the key for ssh commands in your shippable.yml.
 
 ## PEM
 
@@ -30,5 +40,15 @@ To create an account integration for a PEM key, do the following:
 - Enter a name for your key and then paste your key into the textbox labeled `key`.
 - `Save` your key.
 
-You will need to add this key to the Settings of every project you want to use it in. Your PEM key will then be available on your build minion and you can use ssh commands in your shippable.yml. 
+You will need to add this key to both the Settings **and** the shippable.yml of every project you want to use it in. Example shippable.yml integration:
+```yaml
+integrations:
+   key:
+      - integrationName: MyPEMKeyIntegration
+        type: pem-key
+```
+ * `integrationName` is the name of the PEM integration you added to the project settings.
+ * `type` is pem-key
+
+Your PEM key will be available on your build minion in the `/tmp/ssh/` directory, and can be used in your shippable.yml.
 


### PR DESCRIPTION
I couldn't find any documentation earlier on how to use ssh/pem integrations. It got figured out (shippable/support#2646) but hopefully this can help others and save support some time.