### PR TITLE
Add namespace option to cluster documentation.

### DIFF
--- a/sources/pipelines/resources/cluster.md
+++ b/sources/pipelines/resources/cluster.md
@@ -10,12 +10,13 @@ Please note that the resource just points to an existing cluster and does not cr
 You can define a cluster resource by adding it to `shippable.resources.yml`
 ```
 resources:
-  - name: <string>                            	#required
-    type: cluster                             	#required
-    integration: <integration name>			#required
+  - name: <string>                              #required
+    type: cluster                               #required
+    integration: <integration name>             #required
     pointer:
-      sourceName : "<string>"                 	#required
-      region: "<string>"                     	#required for some container services
+      sourceName: "<string>"                    #required
+      region: "<string>"                        #required for some container services
+      namespace: "<string>"                     #optional
 ```
 
 * resource `name` should be an easy to remember text string. This will appear in the visualization of this resource in the SPOG view and in the list of resources in the Pipelines `Resources` tab. It is also used to refer to this resource in the jobs yml. If you have spaces in your name, you'll need to surround the value with quotes, however, as a best practice we recommend not including spaces in your names.
@@ -32,9 +33,10 @@ resources:
 * `sourceName` is the name of the cluster on the Container Service that is represented by this resource. Specify this value in double quotes.
 
 * `region` is the region where the cluster resides, e.g. "us-east-1". Specify this value in double quotes. This is required for the following types of integrations and will take
-in the values that the provider supports
+in the values that the provider supports:
+    * AWS Elastic Container Service (ECS)
+    * Google Container Engine (GKE)
+    * Joyent Triton  
+    * Microsoft Azure Container Service (ACS)
 
-- AWS Elastic Container Service (ECS)
-- Google Container Engine (GKE)
-- Joyent Triton container  
-- Microsoft Azure Container Service (ACS)
+* `namespace` is an option for deployments to Google Container Engine (GKE). If a namespace is specified, deployments will be made to that namespace. Otherwise deployments will be in the default namespace.


### PR DESCRIPTION
Shippable/pm#7343

Documentation for the future `namespace` option, and some indentation changes to make everything line up.