### PR TITLE
DO NOT MERGE - 5.1.2 deployment: adds resourceId, versionId, version propertyBag, and params runSh env vars  

### DIFF
--- a/sources/pipelines/jobs/runSh.md
+++ b/sources/pipelines/jobs/runSh.md
@@ -6,48 +6,112 @@ page_keywords: Deploy multi containers, microservices, Continuous Integration, C
 # runSh
 This job type lets you run any custom scripts as part of your deployment pipeline. Depending on what you want to achieve in your script(s), you can specify input and output resources. You can also send notifications for specific events, like job start, success, or failure.
 
-This is the most powerful job type since it is not a *managed* job, i.e. you write the scripts yourself so you have unlimited flexibility. You should use this job type if there is no managed job that provides the functionality you need. For example, pushing to Heroku is not yet natively supported through a managed job type, so you can write the scripts needed to do this and add it to your pipeline as a job of type `runSh`. 
+This is the most powerful job type since it is not a *managed* job; i.e. you write the scripts yourself so you have unlimited flexibility. You should use this job type if there is no managed job that provides the functionality you need. For example, pushing to Heroku is not yet natively supported through a managed job type, so you can write the scripts needed to do this and add it to your pipeline as a job of type `runSh`.
 
-We are actively adding managed job types to reduce the need to use `runSh`. If you have a scenario that is not handled managed jobs, [open a support request](https://github.com/Shippable/support/issues/) and we'll look into adding a managed job for it.  
+We are actively adding managed job types to reduce the need to use `runSh`. If you have a scenario that is not handled by our managed jobs, [open a support request](https://github.com/Shippable/support/issues/) and we'll look into adding a managed job for it.
 
-##Anatomy of a runSh job
+## Anatomy of a runSh job
 
 The following sample shows the overall structure of a runSh job:
 
 ```
 jobs:
-  - name: <name>								#required
-    type: runSh									#required
-    on_start:									#optional
+  - name: <name>                                #required
+    type: runSh                                 #required
+    on_start:                                   #optional
       - script: echo 'This block executes when the TASK starts'
       - NOTIFY: slackNotification
-    steps:										#required
+    steps:                                      #required
       - IN: <resource>
       - IN: <resource>
       - TASK:
         - script: <command>
         - script: <command>
       - OUT: <resource>
-      - OUT: <resource>      
+      - OUT: <resource>
       - IN: <resource>
       - TASK:
         - script: <command>
-    on_success:									#optional
+    on_success:                                 #optional
       - script: echo 'This block executes after the TASK section executes successfully'
       - NOTIFY: slackNotification
-    on_failure:									#optional
+    on_failure:                                 #optional
       - script: echo 'This block executes if the TASK section fails'
       - NOTIFY: slackNotification
-      
+
 ```
 
 * `name` should be set to something that describes what the job does and is easy to remember. This will be the display name of the job in your pipeline visualization.
 * `type` indicates type of job. In this case it is always `runSh`
-* `on_start` can be used to send a notification indicating the job has started running. 
+* `on_start` can be used to send a notification indicating the job has started running.
 * `steps` section is where the steps of your custom job should be entered. You can have any number of `IN` and `OUT` resources depending on what your job needs. You can also have one or more `TASK` sections where you can enter one or more of your custom scripts. Keep in mind that everything under the `steps` section executes sequentially. Also, environment variables do not persist across `TASK` sections. Read our [advanced runSh documentation](#advancedRunSh) below to find out how to persist environment variables across `TASK` sections.
 * `on_success` can be used to run scripts that only execute if the `TASK` section executes successfully. You can also use this to send a notification as shown in the example above. The `NOTIFY` tag is set to a [Slack notification resource](../resources/notification/).
 * `on_failure` can be used to run scripts that only execute if the `TASK` section fails. You can also use this to send a notification as shown in the example above. The `NOTIFY` tag is set to a [Slack notification resource](../resources/notification/).
- 
+
+## runSh environment variables
+These variables are available for use in the TASK section(s) of every runSh job.
+
+| Env variable        | Description           |
+| ------------- |-------------|
+| RESOURCE_ID    | The ID of the runSh job.|
+| JOB_NAME    | The name of the runSh job.|
+| JOB_TYPE    | The type of the runSh job; this will always be `runSh`.|
+| BUILD_ID    | The ID of the currently running build.|
+| BUILD_NUMBER    | An alternate ID for the build.|
+| BUILD_JOB_ID    | The ID of the currently running buildJob.|
+| BUILD_JOB_NUMBER    | The number of the currently running buildJob, within the build. This is always `1`.|
+| SUBSCRIPTION_ID    | ID of the subscription.|
+| *JOBNAME*_PATH    | The path of the directory containing files for the runSh job. For a runSh job named `myRunShJob`, the variable name would be `MYRUNSHJOB_PATH`. This directory contains two subdirectories: `state` (contains the files that will be saved when the job is complete), and `previousState` (contains the files saved in the previous build).|
+
+### Resource variables
+These variables are added to the environment for all `IN` and `OUT` resources defined for the runSh job. In this case, jobs used as inputs to the runSh job are also considered to be "resources". *RESOURCENAME* is the name of the `IN` or `OUT` resource, in uppercase, with any characters other than letters, numbers, and underscores removed.
+
+| Environment variable        | Description           |
+| ------------- |-------------|
+| *RESOURCENAME*_NAME    | The name of the resource.|
+| *RESOURCENAME*_TYPE    | The type of the resource. For example: `image` or `manifest`.|
+| *RESOURCENAME*_PATH    | The directory containing files for the resource.|
+| *RESOURCENAME*_OPERATION    | The operation of the resource; either `IN` or `OUT`.|
+| *RESOURCENAME*_VERSION_VERSIONNAME    | For `image` resources, this is the tag. For `version` resources and `release` jobs, this is the semantic version. Not used for other resource types.|
+| *RESOURCENAME*_VERSION_VERSIONNUMBER    | The number of the version of the resource being used.|
+| *RESOURCENAME*\_POINTER\_*FIELDNAME*    | Each field defined in that resource's `pointer` section in the yml is added as an environment variable. The field name is sanitized in the same way as the resource name. Objects and arrays are stringified JSON.|
+| *RESOURCENAME*\_SEED\_*FIELDNAME*    | Each field defined in that resource's `seed` section in the yml is added as an environment variable. The field name is sanitized in the same way as the resource name. Objects and arrays are stringified JSON.|
+| *RESOURCENAME*\_INTEGRATION\_*FIELDNAME*    | Explained in the next section.|
+
+### Resource integration variables
+When an `IN` resource uses a subscription integration, the fields associated with that integration are added as environment variables. In the following table, *RESOURCENAME* is the name of the `IN` resource, in uppercase, with any characters other than letters, numbers, and underscores removed. The available environment variables for each integration are as follows:
+
+| Account Integration type                | Environment variables                          |
+|-----------------------------------------|------------------------------------------------|
+| Amazon ECR                              | *RESOURCENAME*_INTEGRATION_AWS_ACCESS_KEY_ID <br/> *RESOURCENAME*_INTEGRATION_AWS_SECRET_ACCESS_KEY |
+| AWS                                     | *RESOURCENAME*_INTEGRATION_AWS_ACCESS_KEY_ID <br/> *RESOURCENAME*_INTEGRATION_AWS_SECRET_ACCESS_KEY <br/> *RESOURCENAME*_INTEGRATION_URL |
+| Amazon Web Services (IAM)               | *RESOURCENAME*_INTEGRATION_ASSUMEROLEARN <br/> *RESOURCENAME*_INTEGRATION_OUTPUT <br/> *RESOURCENAME*_INTEGRATION_URL |
+| Azure Container Service                 | *RESOURCENAME*_INTEGRATION_USERNAME <br/> *RESOURCENAME*_INTEGRATION_URL |
+| Bitbucket                               | *RESOURCENAME*_INTEGRATION_URL <br/> *RESOURCENAME*_INTEGRATION_TOKEN |
+| Bitbucket Server                        | *RESOURCENAME*_INTEGRATION_USERNAME <br/> *RESOURCENAME*_INTEGRATION_URL <br/> *RESOURCENAME*_INTEGRATION_TOKEN |
+| Docker Hub                              | *RESOURCENAME*_INTEGRATION_USERNAME <br/> *RESOURCENAME*_INTEGRATION_PASSWORD <br/> *RESOURCENAME*_INTEGRATION_EMAIL |
+| Docker Cloud                            | *RESOURCENAME*_INTEGRATION_USERNAME <br/> *RESOURCENAME*_INTEGRATION_URL <br/> *RESOURCENAME*_INTEGRATION_TOKEN |
+| Docker Datacenter                       | *RESOURCENAME*_INTEGRATION_USERNAME <br/> *RESOURCENAME*_INTEGRATION_URL <br/> *RESOURCENAME*_INTEGRATION_PASSWORD |
+| Docker Trusted Registry                 | *RESOURCENAME*_INTEGRATION_USERNAME <br/> *RESOURCENAME*_INTEGRATION_URL <br/> *RESOURCENAME*_INTEGRATION_PASSWORD <br/> *RESOURCENAME*_INTEGRATION_EMAIL|
+| Email                                   | *RESOURCENAME*_INTEGRATION_EMAILADDRESS|
+| Event Trigger                           | *RESOURCENAME*_INTEGRATION_PROJECT <br/> *RESOURCENAME*_INTEGRATION_WEBHOOKURL <br/> *RESOURCENAME*_INTEGRATION_AUTHORIZATION |
+| GCR                                     | *RESOURCENAME*_INTEGRATION_JSON_KEY|
+| GitHub                                  | *RESOURCENAME*_INTEGRATION_URL <br/> *RESOURCENAME*_INTEGRATION_TOKEN |
+| GitHub Enterprise                       | *RESOURCENAME*_INTEGRATION_URL <br/> *RESOURCENAME*_INTEGRATION_TOKEN |
+| Gitlab                                  | *RESOURCENAME*_INTEGRATION_URL <br/> *RESOURCENAME*_INTEGRATION_TOKEN |
+| Google Container Engine                 | *RESOURCENAME*_INTEGRATION_JSON_KEY <br/> *RESOURCENAME*_INTEGRATION_URL |
+| Hipchat                                 | *RESOURCENAME*_INTEGRATION_TOKEN |
+| Jenkins                                 | *RESOURCENAME*_INTEGRATION_USERNAME <br/> *RESOURCENAME*_INTEGRATION_PASSWORD <br/> *RESOURCENAME*_INTEGRATION_URL |
+| JFrog Artifactory                       | *RESOURCENAME*_INTEGRATION_USERNAME <br/> *RESOURCENAME*_INTEGRATION_PASSWORD <br/> *RESOURCENAME*_INTEGRATION_URL |
+| Joyent Triton Public Cloud              | *RESOURCENAME*_INTEGRATION_USERNAME <br/> *RESOURCENAME*_INTEGRATION_URL <br/> *RESOURCENAME*_INTEGRATION_VALIDITYPERIOD <br/> *RESOURCENAME*_INTEGRATION_PUBLICKEY <br/> *RESOURCENAME*_INTEGRATION_PRIVATEKEY| <br/> *RESOURCENAME*_INTEGRATION_CERTIFICATES |
+| Node Cluster                            | *RESOURCENAME*_INTEGRATION_NODES <br/> *RESOURCENAME*_INTEGRATION_PUBLICKEY <br/> *RESOURCENAME*_INTEGRATION_PRIVATEKEY|
+| PEM key                                 | *RESOURCENAME*_INTEGRATION_KEY |
+| Private Docker registry                 | *RESOURCENAME*_INTEGRATION_USERNAME <br/> *RESOURCENAME*_INTEGRATION_URL <br/> *RESOURCENAME*_INTEGRATION_PASSWORD <br/> *RESOURCENAME*_INTEGRATION_EMAIL |               |
+| Quay.io                                 | *RESOURCENAME*_INTEGRATION_USERNAME <br/> *RESOURCENAME*_INTEGRATION_URL <br/> *RESOURCENAME*_INTEGRATION_PASSWORD <br/> *RESOURCENAME*_INTEGRATION_EMAIL <br/> *RESOURCENAME*_INTEGRATION_ACCESSTOKEN |
+| Slack                                   | *RESOURCENAME*_INTEGRATION_WEBHOOKURL |
+| SSH key                                 | *RESOURCENAME*_INTEGRATION_PUBLICKEY <br/> *RESOURCENAME*_INTEGRATION_PRIVATEKEY |
+
+
 <a name="advancedRunSh"></a>
 ##runSh scenarios
 

--- a/sources/pipelines/jobs/runSh.md
+++ b/sources/pipelines/jobs/runSh.md
@@ -69,14 +69,19 @@ These variables are added to the environment for all `IN` and `OUT` resources de
 | Environment variable        | Description           |
 | ------------- |-------------|
 | *RESOURCENAME*_NAME    | The name of the resource.|
+| *RESOURCENAME*_ID    | The ID of the resource.|
 | *RESOURCENAME*_TYPE    | The type of the resource. For example: `image` or `manifest`.|
 | *RESOURCENAME*_PATH    | The directory containing files for the resource.|
 | *RESOURCENAME*_OPERATION    | The operation of the resource; either `IN` or `OUT`.|
 | *RESOURCENAME*_VERSION_VERSIONNAME    | For `image` resources, this is the tag. For `version` resources and `release` jobs, this is the semantic version. Not used for other resource types.|
 | *RESOURCENAME*_VERSION_VERSIONNUMBER    | The number of the version of the resource being used.|
+| *RESOURCENAME*_VERSION_VERSIONID    | The ID of the version of the resource being used.|
+| *RESOURCENAME*\_VERSION\_*FIELDNAME*    | `dockerOptions`-, `params`-, and `replicas`-type resources have a `version` section in the yml. Fields defined in these resources' `version` sections are added as environment variables. The field name is sanitized in the same way as the resource name. Objects and arrays are stringified JSON.|
 | *RESOURCENAME*\_POINTER\_*FIELDNAME*    | Each field defined in that resource's `pointer` section in the yml is added as an environment variable. The field name is sanitized in the same way as the resource name. Objects and arrays are stringified JSON.|
 | *RESOURCENAME*\_SEED\_*FIELDNAME*    | Each field defined in that resource's `seed` section in the yml is added as an environment variable. The field name is sanitized in the same way as the resource name. Objects and arrays are stringified JSON.|
+| *RESOURCENAME*\_PARAMS\_*FIELDNAME*    | Only added for `param`-type resources. Each field defined in that resource's `params` section in the yml is added as an environment variable. The field name is sanitized in the same way as the resource name. Objects and arrays are stringified JSON. Secure variables are decrypted.|
 | *RESOURCENAME*\_INTEGRATION\_*FIELDNAME*    | Explained in the next section.|
+
 
 ### Resource integration variables
 When an `IN` resource uses a subscription integration, the fields associated with that integration are added as environment variables. In the following table, *RESOURCENAME* is the name of the `IN` resource, in uppercase, with any characters other than letters, numbers, and underscores removed. The available environment variables for each integration are as follows:

--- a/sources/tutorials/pipelines/runShUseIntegrations.md
+++ b/sources/tutorials/pipelines/runShUseIntegrations.md
@@ -3,85 +3,73 @@ page_description: Continuous deployment tutorials
 page_keywords: containers, lxc, docker, Continuous Integration, Continuous Deployment, CI/CD, testing, automation, Tokens, account settings
 
 #Using integrations with your runSh job
-The `runSh` job type is a custom job that lets you run any custom scripts as part of your deployment pipeline. For scenarios where you want to interact with a supported third party service, you will need to add an integration as an `IN` for your custom job.
+The `runSh` job type is a custom job that lets you run any custom scripts as part of your deployment pipeline. For scenarios where you want to interact with a supported third party service, you will need to add an integration to your custom job.
 
-For example, if you want to push to a Docker registry or pull a private Docker image from a registry, you will need to add an integration for the Docker registry. For more on Integrations, read our [Integrations overview page.](/integrations/overview/) 
+For example, if you want to push to a Docker registry or pull a private Docker image from a registry, you must add an integration for the Docker registry. For more on Integrations, read our [Integrations overview page.](/integrations/overview/)
 
+There are two ways to add an integration to your custom job. The first is to create an `integration`-type resource, and add it to the custom job. The second is by adding other resource types as inputs to your custom job; any integrations associated with those resources will be automatically added to your job.
 
-###Specifying an integration as an input
-To use an integration with your custom job, you should first define it in your `shippable.resources.yml`:
+### Specifying an integration resource as an input
+To add an integration resource to your custom job, you first define it in your `shippable.resources.yml`:
 
 ```
 resources:
-  - name: myIntegration					#required
-    type: integration				    #required
-    integration: myCredentials			#required
+  - name: dockerCredentials                #required
+    type: integration                      #required
+    integration: myDockerHubIntegration    #required
 ```
 
-Next, specify the integration resource in your `shippable.jobs.yml`:
+Next, specify the integration resource as an input to the custom job in your `shippable.jobs.yml`:
 
 ```
 jobs:
   - name: myCustomJob
     type: runSh
     steps:
-      - IN: myIntegration
+      - IN: dockerCredentials
       - TASK:
         - script: ./doStuffWithIntegration.sh
 ```
 
+### Adding integrations associated with other resource types
+When a resource is added as an input to a custom job, the integration associated with the resource is also added. This works for all types of resources. To add a resource as an input, you first define it in your `shippable.resources.yml`:
+```
+resources:
+  - name: myImage
+    type: image
+    integration: myDockerHubIntegration
+    pointer:
+      sourceName: library/busybox
+    seed:
+      versionName: latest
+```
 
-###Extracting data from integration
-Now that you have added the integration as an `IN` resource, you need to extract data from your integration in order to use it in your custom script. For example, if your integration is for Docker Hub, you will need to extract the username and password from your integration resource so you can include a `docker login` command in your custom script.
-
-The information from your integration is stored in the `./IN/<resource name>integration.env` file. You can run the comand shown below to export your credentials:
+Then, add your image resource in your `shippable.jobs.yml`:
 
 ```
-  . ./IN/myIntegration/integration.env
+jobs:
+  - name: myCustomJob
+    type: runSh
+    steps:
+      - IN: myImage
+      - TASK:
+        - script: ./doStuffWithIntegration.sh
 ```
-This will export the data into environment variables with the same names as the field in your account integration. Exported environment variables are always in lower case.
 
-For example, the environment variables are $username, $password, and $email for Docker Hub integrations:
+### Using integration data
+In both of the above examples, the integration `myDockerHubIntegration` was added to the runSh job. (In the first example, it was added to `myCustomJob` as part of the `dockerCredentials` resource; in the second, it was added because it is associated with the `myImage` resource.) The fields from `myDockerHubIntegration` are all made available as environment variables to the scripts in the runSh job. For a list of variables created for each integration, read our [runSh page](/pipelines/jobs/runSh/#resource-integration-variables).
 
-<img src="../../images/pipelines/dockerHubCreds1.png" alt="Docker Hub credentials " style="width:400px;"/>
+In this case, there are three environment variables created for this Docker Hub integration. Their names will be:
 
-You can use then use these environment variables in your custom script as shown below:
+- *RESOURCENAME*_INTEGRATION_USERNAME
+- *RESOURCENAME*_INTEGRATION_PASSWORD
+- *RESOURCENAME*_INTEGRATION_EMAIL
 
+where *RESOURCENAME* is the name of the resource added to the custom job. In the first example, *RESOURCENAME* will be `DOCKERCREDENTIALS`; in the second example, *RESOURCENAME* will be `MYIMAGE`.
+
+We'll assume we added `dockerCredentials` to the custom job, so the *RESOURCENAME* is `DOCKERCREDENTIALS`. Our `doStuffWithIntegration.sh` script can now use the `myDockerHubIntegration` environment variables to log into Docker Hub:
 ```
 dockerLogin() {
-  . ./IN/myIntegration/integration.env		
-  docker login -u $username -p $password
+  docker login -u $DOCKERCREDENTIALS_INTEGRATION_USERNAME -p $DOCKERCREDENTIALS_INTEGRATION_PASSWORD
 }
 ```
-
-##integration.env reference
-
-The example above shows you how to abstract data from integration.env for Docker Hub integrations. We currently support many different integration types, so you need a comprehensive mapping of integration type vs environment variable names.
-
-The table below shows you the environment variables that are available for your custom scripts when you run the `. ./IN/<resource name>/integration.env` command:
-
-
-| Account Integration type                | Environment variables                          |
-|-----------------------------------------|------------------------------------------------|
-| Amazon ECR                              | $aws_access_key_id $aws_secret_access_key      |
-| AWS                                     | $aws_access_key_id $aws_secret_access_key $url |
-| Azure Container Service                 | $username $url                                 |
-| Bitbucket                               | $url $token                                    |
-| Bitbucket Server                        | $username $url $token                          |
-| Docker Hub                              | $username $password $email                     |
-| Docker Cloud                            | $username $token $url                          |
-| Docker Datacenter                       | $username $password $url                       |
-| Docker Trusted Registry                 | $username $password $email $url               |
-| GCR                                     | $json_key                                      |
-| GitHub                                  | $url $token                                    |
-| GitHub Enterprise                       | $url $token                                    |
-| Gitlab                                  | $url $token                                    |
-| Google Container Engine                 | $json_key $url                                 |
-| Hipchat                                 | $token                                         |
-| Joyent Triton Elastic Container Service | $username $url                                 |
-| Joyent Triton Public Cloud              | $username $url $validityperiod                 |
-| PEM key                                 | $key                                           |
-| Private Docker registry                 | $username $password $email $url               |
-| Quay.io                                 | $username $password $email $url $accesstoken  |
-| Slack                                   | $webhookurl                                    |
-| SSH key                                 | $publickey $privatekey                         |  


### PR DESCRIPTION
https://github.com/Shippable/docsv2/issues/624

Adds the following env vars to the table:
- RESOURCE_ID
- RESOURCENAME_VERSION_VERSIONID
- RESOURCENAME_VERSION_FIELDNAME (these are the fields in the property bag; for dockerOptions, params, and replicas)
- RESOURCENAME_PARAMS_FIELDNAME for params-type resources only

![jan20envvars](https://cloud.githubusercontent.com/assets/7757711/21831256/38ccdfa4-d757-11e6-903a-e34cf579755c.png)
