### PR TITLE
dockerOptions docs spelling/caps

### DIFF
--- a/sources/pipelines/resources/dockerOptions.md
+++ b/sources/pipelines/resources/dockerOptions.md
@@ -394,7 +394,7 @@ Top level docker options
   - name: <string>
   - type: dockerOptions
   - version:
-      Service:
+      service:
         loadBalancer:
          - <object>
         desiredCount: <number>
@@ -403,7 +403,7 @@ Top level docker options
         deploymentConfiguration:
           "maximumPercent": <number>,
           "minimumHealthyPercent": <number>
-      Task Definition:
+      taskDefinition:
         family: <string>
         taskRoleArn: <string>
         networkMode: <string>
@@ -420,7 +420,7 @@ resources:
   - name: <string>
   - type: dockerOptions
   - version:
-      Pod:
+      pod:
         terminationGracePeriodSeconds: <number>
         activeDeadlineSeconds: <number>
         dnsPolicy: <string>


### PR DESCRIPTION
https://github.com/Shippable/docsv2/issues/629

in ECS, in the "Top level docker options" section:
- we say `Service` but it should be `service`
- we say `Task Definition` but it should be `taskDefinition`

in "Top level docker options" for GKE:
- we say `Pod` but it should be `pod`
