### PR TITLE
DO NOT MERGE: 5.1.2 deployment - Add provision jobs for GKE services

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ pages:
     - manifest: pipelines/jobs/manifest.md
     - deploy: pipelines/jobs/deploy.md
     - release: pipelines/jobs/release.md
+    - provision: pipelines/jobs/provision.md
     - runSh: pipelines/jobs/runSh.md
     - jenkinsJob: pipelines/jobs/jenkinsJob.md
   - Triggers: pipelines/triggers.md

--- a/sources/pipelines/jobs/deploy.md
+++ b/sources/pipelines/jobs/deploy.md
@@ -23,7 +23,7 @@ jobs:
       - IN: <manifest>                			#required
       - IN: <cluster>                      	#required
       - IN: <dockerOptions>						#optional override
-      - IN: <params>                       	#optional override  
+      - IN: <params>                       	#optional override
       - IN: <replicas>							#optional override
 ```
 
@@ -121,14 +121,14 @@ Shippable supports 3 types of deployments:
 
 By default, deployments to Amazon ECS, Google Container Engine and Joyent Triton are blue-green deployments.
 
-* The second type is **upgrade** deployments where we deploy the newer version of the service and bring down the older version without waiting for the newer version to be up and running. Depending on how your Container Service handles this scenario, there might be some downtime with this type of deployment. In our experience, Amazon ECS handles this with no downtime, but with Google Container Engine and Joyent Triton, there might be a brief hiccup if the new container takes some time to come up.  
+* The second type is **upgrade** deployments where we deploy the newer version of the service and bring down the older version without waiting for the newer version to be up and running. Depending on how your Container Service handles this scenario, there might be some downtime with this type of deployment. In our experience, Amazon ECS handles this with no downtime, but with Google Container Engine and Joyent Triton, there might be a brief hiccup if the new container takes some time to come up.
 
-* The third type is **replace** deployments where we bring down the old version and wait until the application is stopped successfully before deploying the new version. This type of deployment always has some downtime, depending on how quickly the Container Service is able to stop and start applications. It is mostly intended to be used for deployments to clusters where it's not possible to run more than one instance of the same task in parallel due to a limited number of machines.  
+* The third type is **replace** deployments where we bring down the old version and wait until the application is stopped successfully before deploying the new version. This type of deployment always has some downtime, depending on how quickly the Container Service is able to stop and start applications. It is mostly intended to be used for deployments to clusters where it's not possible to run more than one instance of the same task in parallel due to a limited number of machines.
 
 If you want to specify upgrade or replace deployment instead of the default blueGreen, you can do it in your `shippable.jobs.yml`:
 
 ```
-jobs:  
+jobs:
   - name: <job name>
     type: deploy
     steps:
@@ -140,9 +140,9 @@ jobs:
 Please make sure the `TASK` tag is the last one in the list of steps.
 
 ##Attaching a Load Balancer
-As part of your job, you can choose to deploy an image in your manifest behind a load balancer. Please note that this option currently only works with AWS Classic and Application Load Balancers. Also, the load balancer must be already created on AWS and then configured on Shippable. We do not handle creation of the load balancer.
+As part of your job, you can choose to deploy an image in your manifest behind a load balancer. Please note that this option currently only works with AWS Classic and Application Load Balancers. (Google Container Engine load balancer-type services can be created using a [provision](provision/) job.) Also, the load balancer must be already created on AWS and then configured on Shippable. We do not handle creation of the load balancer as part of deploy jobs.
 
-```  
+```
 jobs:
   - name: <job name>
     type: deploy

--- a/sources/pipelines/jobs/overview.md
+++ b/sources/pipelines/jobs/overview.md
@@ -3,7 +3,7 @@ page_description: List of supported jobs
 page_keywords: Deploy multi containers, microservices, Continuous Integration, Continuous Deployment, CI/CD, testing, automation, pipelines, docker, lxc
 
 # Jobs
-Jobs are the executable units of your pipelines. They take one or more [resources](../resources/overview/) as inputs, perform some operation on the inputs, and can output to other resources. Jobs can also act as inputs for other jobs, which serves to daisy-chain a series of jobs into a pipeline.   
+Jobs are the executable units of your pipelines. They take one or more [resources](../resources/overview/) as inputs, perform some operation on the inputs, and can output to other resources. Jobs can also act as inputs for other jobs, which serves to daisy-chain a series of jobs into a pipeline.
 
 <img src="../../images/jobs/jobWorkflow.png" alt="Connecting jobs into a pipeline" style="width:1000px;vertical-align: middle;display: block;margin-left: auto;margin-right: auto;"/>
 
@@ -13,7 +13,7 @@ Shippable supports jobs in two ways - **managed** and **unmanaged**.
 
 **Unmanaged jobs** are available for you to provide you complete flexibility to do pretty much anything you need by configuring the job with custom shell scripts. These jobs can take any supported resource as an input and can output to any resource depending on your configuration.
 
-We currently support 4 types of jobs:
+We currently support 6 types of jobs:
 
 - [manifest](manifest/): This managed job type is used for creating and versioning an application or service definition. Your service definition consists of one or more Docker images, options you want to run your containers with, and environment parameters.
 
@@ -21,7 +21,11 @@ We currently support 4 types of jobs:
 
 - [release](release/): This managed job type is used to perform release management. You can apply semantic versioning to your services or entire application at any stage of your pipeline.
 
+- [provision](provision/): This managed job type is used to create objects on a supported Container Service.
+
 - [runSh](runSh/): This is an unmanaged job that can be configured to do almost anything with custom shell scripts.
+
+- [jenkinsJob](jenkinsJob/): This managed job type allows you to connect an existing Jenkins job to your Shippable pipeline.
 
 Jobs, [resources](../resources/overview/), and [triggers](../triggers/) together can be used to model any deployment pipeline, regardless of the complexity of your application.
 
@@ -58,7 +62,7 @@ jobs:
     type: manifest | deploy | release | runSh
     steps:
       - IN: <resource>
-      - IN: <resource>							
+      - IN: <resource>
 
 ```
 This a very simple job which needs 2 INput resources to perform whatever that job is designed to do.

--- a/sources/pipelines/jobs/provision.md
+++ b/sources/pipelines/jobs/provision.md
@@ -1,0 +1,33 @@
+page_title: Unified Pipeline Resources
+page_description: List of supported resources
+page_keywords: Deploy multi containers, microservices, Continuous Integration, Continuous Deployment, CI/CD, testing, automation, pipelines, docker, lxc
+
+# provision
+
+Provision jobs are used to create objects on a [supported Container Service](../../integrations/overview/#container-services). When provision jobs are deleted, the resulting objects are also deleted from the container service.
+
+Provision jobs are only supported for Google Container Engine (GKE) services at this time.
+
+A provision job is configured in the `shippable.jobs.yml` file. Here is an example:
+
+```
+jobs:
+  - name: <string>                                                   #required
+    type: provision                                                  #required
+    steps:
+      - IN: <name of the resource to be provisioned>                 #required
+      - IN: <additional resource to be provisioned>                  #optional
+
+```
+- `name` is a text string of your choice. This will appear in the visualization of this job in the SPOG view.  If you have spaces in your name, you'll need to surround the value with quotes. However, as a best practice, we recommend not including spaces in your names.
+- `type` is always set to `provision`.
+- `IN` steps: Each `IN` step specifies the `name` of a resource you wish to provision. Provision jobs take one or more resources as inputs. The resource to be provisioned is defined in the `shippable.resources.yml` file, and must be one of our supported objects (listed below).
+
+
+## Supported Objects
+
+The resources you can provision vary by container service. Below is a list of currently supported objects for each service.
+
+### Google Container Engine
+#### Services
+All four Kubernetes [service](https://kubernetes.io/docs/user-guide/services/) types are supported: LoadBalancer, NodePort, ExternalName, and ClusterIP. Services are configured as [loadBalancer](../resources/loadBalancer/) resources in the `shippable.resources.yml`.

--- a/sources/pipelines/resources/loadBalancer.md
+++ b/sources/pipelines/resources/loadBalancer.md
@@ -1,6 +1,6 @@
 # loadBalancer
 
-A `loadBalancer` resource is used to deploy your service manifest with a load balancer. Please note that this is only supported for Amazon's EC2 Container Service (ECS) at this time. It is used as an input for [deploy jobs](../jobs/deploy/).
+There are two ways that a `loadBalancer` resource can be used.  It may be used as an input to a [deploy job](../jobs/deploy/) to deploy a service manifest with a load balancer; this is only supported for Amazon's EC2 Container Service (ECS) at this time. Or, it can be used as an input to a [provision job](../jobs/provision/) to create a new load balancer in a Google Container Engine (GKE) cluster.
 
 You can create a `loadBalancer` resource by adding it to `shippable.resources.yml`:
 
@@ -8,20 +8,64 @@ You can create a `loadBalancer` resource by adding it to `shippable.resources.ym
 resources:
   - name: <string>                              #required
     type: loadBalancer                          #required
+    integration: <string>
     pointer:
-      sourceName: "<string>"
-      method: application | classic
+      sourceName: "<string>"                    #required
+      method: application | classic | ClusterIP | ExternalName | LoadBalancer | NodePort
       role: <string>                            #optional
+      clusterName: <string>
+      region: <string>
+      namespace: <string>
+    version:
+      ports:
+        - name: <string>
+          protocol: TCP | UDP
+          port: <integer>
+          targetPort: <string>
+          nodePort: <integer>
+      selector:
+        <string>: <string>
+      clusterIP: None | "" | <string>
+      externalIPs:
+        - <string>
+      sessionAffinity: ClientIP | None
+      loadBalancerIP: <string>
+      loadBalancerSourceRanges:
+        - <string>
+      externalName: <string>
 
 ```
 
-* `name` should be an easy to remember text string. This will appear in the visualization of this resource in the SPOG view and the list of resources in the Pipelines `Resources` tab. It is also used to refer to this resource in the jobs yml. If you have spaces in your name, you'll need to surround the value with quotes, however, as a best practice we recommend not including spaces in your names.
+* `name` should be an easy to remember text string. This will appear in the visualization of this resource in the SPOG view and the list of resources in the Pipelines `Resources` tab. It is also used to refer to this resource in the jobs yml. If you have spaces in your name, you'll need to surround the value with quotes. However, as a best practice, we recommend not including spaces in your names.
 
 * `type` is always set to 'loadBalancer'.
 
-* `pointer` section provides information about the load balancer:
+* `integration` is required to use the `loadBalancer` as an input to a [provision job](../jobs/provision/).  It should be the name of a [Google Container Engine (GKE)](../../integrations/containerServices/gke/) subscription integration. This is not needed for Amazon EC2 Container Service (ECS) load balancers.
+
+* `pointer` section provides information about the location and type of the load balancer:
     * `sourceName` should be set depending on the type of load balancer. It is good practice to surround this field with quotes to avoid any parsing issues due to special characters.
         * For <a href="https://aws.amazon.com/elasticloadbalancing/classicloadbalancer/" target="_blank">Classic Load Balancers</a>, set this to the load balancer name
-        * For <a href="https://aws.amazon.com/elasticloadbalancing/applicationloadbalancer/" target="_blank">Application Load Balancers</a>, set it to the target group arn  
-    * `method` is set to `application` for Application Load Balancers and `classic` for Classic Load Balancers
-    * `role` is set to the name of the AWS IAM role used to update the load balancer. This role should have a trust relationship allowing "ecs.amazonaws.com". If no role is specified, a role with the correct trust relationship will be used if one exists.
+        * For <a href="https://aws.amazon.com/elasticloadbalancing/applicationloadbalancer/" target="_blank">Application Load Balancers</a>, set it to the target group arn
+        * For [Google Container Engine (GKE) services](https://kubernetes.io/docs/user-guide/services/) (load balancers), this will be used as the service name and may only contain lowercase letters, numbers, `-`, and `.`.
+    * `method` corresponds to the type of load balancer:
+        * For Amazon's EC2 Container Service (ECS), the choices are `application` for Application Load Balancers and `classic` for Classic Load Balancers,
+        * For Google Container Engine (GKE), the choices are `ClusterIP`, `ExternalName`, `LoadBalancer`, and `NodePort`.  If no `method` is specified, the default is `ClusterIP`.
+    * `role` is optional for Amazon's EC2 Container Service (ECS) and not used for other providers.  Set `role` to the name of the AWS IAM role used to update the load balancer. This role should have a trust relationship allowing "ecs.amazonaws.com". If no role is specified, a role with the correct trust relationship will be used if one exists.
+    * `clusterName` is required for `loadBalancer` resources used as input to a [provision job](../jobs/provision/).  Set `clusterName` to the name of the cluster to which the load balancer will belong.
+    * `region` is required for `loadBalancer` resources used as input to a [provision job](../jobs/provision/).  Set `region` to the name of region containing the cluster.
+    * `namespace` is optional for Google Container Engine (GKE).  If a `namespace` is specified the load balancer will be created in that namespace.  Otherwise the `default` namespace will be used.
+
+* `version` section is required for `loadBalancer` resources used as an input to [provision job](../jobs/provision/). It is not used for `loadBalancer` resources that are inputs to [deploy jobs](../jobs/deploy/).
+    * `ports` is an list of ports to be managed by the load balancer, each with the following fields:
+        * `name` is required for Google Container Engine (GKE) when there is more than one port.  It may only contain lowercase letters, numbers, `-`, and `.`.
+        * `protocol` may be TCP or UDP.  The default is TCP.
+        * `port` is the service port exposed on the cluster IP.  This is required when `ports` is specified.
+        * `targetPort` is an optional port to access the pod.
+        * `nodePort` is the port exposed on the node.  A port will be assigned if not specified.
+    * `selector` consists of key-value pairs matching the labels of the targeted pods.
+    * `clusterIP` is the optional IP address of the service to be created.  Valid values are: None, "", and valid IP addresses.  By default, an address will be assigned.  This is not used when `method` is ExternalName.
+    * `externalIPs` is an optional list of IP addresses for which nodes will accept traffic.  This is mapped to the `externalIPs` field in the Kubernetes service.
+    * `sessionAffinity` is optional and may be either None or ClientIP.  The default is None.
+    * `loadBalancerIP` is optional and only used when the method is LoadBalancer.  It is mapped to the loadBalancerIP field in the Kubernetes service.
+    * `loadBalancerSourceRanges` is optional and
+    * `externalName` is required when the method is ExternalName and is the valid DNS name to be returned as CNAME for the service.

--- a/sources/pipelines/resources/overview.md
+++ b/sources/pipelines/resources/overview.md
@@ -4,7 +4,7 @@ page_keywords: Deploy multi containers, microservices, Continuous Integration, C
 
 <br>
 # Resources
-Resources are the basic building blocks of your pipelines. They are inputs for and sometimes outputs from the executable units of your pipeline, aka [Jobs](../jobs/overview/).  
+Resources are the basic building blocks of your pipelines. They are inputs for and sometimes outputs from the executable units of your pipeline, aka [Jobs](../jobs/overview/).
 
 A key characteristic of resources is that they can be versioned and are immutable. A specific version of a resource is idempotent. i.e. it returns the same result every single time it is fetched. For example, git commit sha is always idempotent.
 
@@ -21,7 +21,7 @@ There are several resources that are pre-defined as part of the platform and wor
 - [cluster](cluster/): Cluster that defines a container service
 - [notification](notification/): Notifications for job success or failure
 - [integration](integration/): Credentials for third party services
-- [loadBalancer](loadBalancer/): AWS Classic and Application Load Balancers
+- [loadBalancer](loadBalancer/): AWS Classic and Application Load Balancers, or Google Container Engine (GKE) services.
 - [time](time/): Trigger a job at a specific day and time
 
 At this time, we do not support definition of custom resources. If you need a resource that is not listed above, send us an email at [support@shippable.com](mailto:support@shippable.com)


### PR DESCRIPTION
https://github.com/Shippable/docsv2/issues/631

Adds provision job page:
![provisionjob](https://cloud.githubusercontent.com/assets/7757711/21999021/ce51d84c-dbec-11e6-9f81-ce3293ead420.png)

Updates jobs overview to reference provisions (as well as jenkinsJobs):
![jobsoverview](https://cloud.githubusercontent.com/assets/7757711/21999026/e08c7648-dbec-11e6-8243-4dd4a23af99f.png)

Updates loadBalancer resource page to include info on GKE services:
![lbpart1](https://cloud.githubusercontent.com/assets/7757711/21999041/f34bdd3c-dbec-11e6-99b9-80e71e0e9c7f.png)
![lbpart2](https://cloud.githubusercontent.com/assets/7757711/21999045/f8378c38-dbec-11e6-9ce0-8221e1411248.png)

Updates the loadBalancer reference in the resources overview to reflect GKE:
![resourcesoverview](https://cloud.githubusercontent.com/assets/7757711/21999334/6f599c74-dbee-11e6-9840-e698921ca7e9.png)

Updates the loadBalancer reference in the deploy jobs docs to reflect GKE:
![deploylb](https://cloud.githubusercontent.com/assets/7757711/21999349/8b749030-dbee-11e6-942f-14758e0df407.png)

