### PR TITLE
#689; adds more integration types to runCLI documentation.

### DIFF
--- a/sources/pipelines/jobs/runCLI.md
+++ b/sources/pipelines/jobs/runCLI.md
@@ -55,9 +55,12 @@ The runCLI job uses the subscription integration specified in the [cliConfig](..
 | AWS                                 | [AWS CLI](https://aws.amazon.com/cli/); [EB (Elastic Beanstalk) CLI](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3.html) |
 | Amazon EC2 Container Registry (ECR) | [Docker Engine](https://docs.docker.com/engine/reference/commandline/docker/) |
 | Docker Hub                          | [Docker Engine](https://docs.docker.com/engine/reference/commandline/docker/) |
+| Docker Trusted Registry             | [Docker Engine](https://docs.docker.com/engine/reference/commandline/docker/) |
 | Google Container Engine             | [gcloud](https://cloud.google.com/sdk/gcloud/); [kubectl](https://kubernetes.io/docs/user-guide/kubectl/) |
 | Google Container Registry (GCR)     | [Docker Engine](https://docs.docker.com/engine/reference/commandline/docker/) |
+| JFrog Artifactory                   | [JFrog CLI](https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory) |
 | Kubernetes                          | [kubectl](https://kubernetes.io/docs/user-guide/kubectl/) |
+| Private Docker Registry             | [Docker Engine](https://docs.docker.com/engine/reference/commandline/docker/) |
 | Quay.io                             | [Docker Engine](https://docs.docker.com/engine/reference/commandline/docker/) |
 
 It's worth noting that if a runCLI job receives multiple `cliConfig` resources for the same provider, we will use the credentials contained in the last listed `cliConfig` when authenticating.

--- a/sources/pipelines/resources/cliConfig.md
+++ b/sources/pipelines/resources/cliConfig.md
@@ -75,7 +75,7 @@ resources:
 
 ### Docker
 
-A Docker integration is used to authenticate with Docker Hub and will be used in a [runCLI job](../jobs/runCLI/) to `docker login` before the scripts in the `TASK` section. It may be created in `shippable.resources.yml` as follows:
+A [Docker](../../integrations/imageRegistries/dockerHub/) integration is used to authenticate with Docker Hub and will be used in a [runCLI job](../jobs/runCLI/) to `docker login` before the scripts in the `TASK` section. It may be created in `shippable.resources.yml` as follows:
 
 ```
 resources:
@@ -87,6 +87,21 @@ resources:
 * `name` should be an easy to remember text string. This will appear in the visualization of this job in the SPOG view.
 * `type` is 'cliConfig'
 * `integration` should be the name of a [Docker](../../integrations/imageRegistries/dockerHub/) integration that has been [enabled for the subscription](../../navigatingUI/subscriptions/settings/#adding-integrations). Make sure that this name matches the name used in the subscription settings.
+
+### Docker Trusted Registry
+
+A [Docker Trusted Registry](../../integrations/imageRegistries/dockerTrustedRegistry/) integration is used to authenticate with that registry and if this resource is added to a [runCLI job](../jobs/runCLI/), it will be used to `docker login` before the scripts in the `TASK` section. It may be created in `shippable.resources.yml` as follows:
+
+```
+resources:
+  - name: <string>                              #required
+    type: cliConfig                             #required
+    integration: <string>                       #required
+```
+
+* `name` should be an easy to remember text string. This will appear in the visualization of this job in the SPOG view.
+* `type` is 'cliConfig'
+* `integration` should be the name of a [Docker Trusted Registry](../../integrations/imageRegistries/dockerTrustedRegistry/) integration that has been [enabled for the subscription](../../navigatingUI/subscriptions/settings/#adding-integrations). Make sure that this name matches the name used in the subscription settings.
 
 ### Google Container Registry (GCR)
 
@@ -127,6 +142,21 @@ resources:
 
 *NOTE:* Using multiple Google Container Engine (GKE) integrations, GKE and Kubernetes integrations, or GKE and Google Container Registry (GCR) integrations in the same runCLI job is not supported.
 
+### JFrog Artifactory
+
+A [JFrog Artifactory](../../integrations/artifactRegistries/jfrogArtifactory/) integration may be used to configure credentials with the JFrog Artifactory CLI in a [runCLI job](../jobs/runCLI/) before the scripts in the `TASK` section. It is specified as follows:
+
+```
+resources:
+  - name: <string>                              #required
+    type: cliConfig                             #required
+    integration: <string>                       #required
+```
+
+* `name` should be an easy to remember text string. This will appear in the visualization of this job in the SPOG view.
+* `type` is 'cliConfig'
+* `integration` should be the name of a [JFrog Artifactory](../../integrations/artifactRegistries/jfrogArtifactory/) integration that has been [enabled for the subscription](../../navigatingUI/subscriptions/settings/#adding-integrations). Make sure that this name matches the name used in the subscription settings.
+
 ### Kubernetes
 
 A [Kubernetes](../../integrations/containerServices/kubernetes/) integration may be used to authenticate with the Kubernetes master in a [runCLI job](../jobs/runCLI/) before the scripts in the `TASK` section. It is specified as follows:
@@ -143,6 +173,21 @@ resources:
 * `integration` should be the name of a [Kubernetes](../../integrations/containerServices/kubernetes/) integration that has been [enabled for the subscription](../../navigatingUI/subscriptions/settings/#adding-integrations). Make sure that this name matches the name used in the subscription settings. Kubernetes integrations using a bastion host are not supported with [runCLI jobs](../jobs/runCLI/) at this time.
 
 *NOTE:* Using multiple Kubernetes integrations or both Kubernetes and Google Container Engine (GKE) integrations in the same runCLI job is not supported.
+
+### Private Docker Registry
+
+A [Private Docker Registry](../../integrations/imageRegistries/privateRegistry/) integration is used to authenticate with that registry and will be used to `docker login` before the scripts in the `TASK` section in a [runCLI job](../jobs/runCLI/). It may be created in `shippable.resources.yml` as follows:
+
+```
+resources:
+  - name: <string>                              #required
+    type: cliConfig                             #required
+    integration: <string>                       #required
+```
+
+* `name` should be an easy to remember text string. This will appear in the visualization of this job in the SPOG view.
+* `type` is 'cliConfig'
+* `integration` should be the name of a [Private Docker Registry](../../integrations/imageRegistries/privateRegistry/) integration that has been [enabled for the subscription](../../navigatingUI/subscriptions/settings/#adding-integrations). Make sure that this name matches the name used in the subscription settings.
 
 ### Quay.io
 


### PR DESCRIPTION
#689 

Adds the rest of the supported integration types to the runCLI documentation.  This is for the next release.