### PR TITLE
modify docs for runCI support

### DIFF
--- a/sources/tutorials/pipelines/connectingCiPipelines.md
+++ b/sources/tutorials/pipelines/connectingCiPipelines.md
@@ -15,7 +15,7 @@ alt="connecting CI with pipelines" style="width:800px;vertical-align: middle;dis
 
 We're going to see how we can replace the question mark in the picture above with a trigger that will trigger a new version of myImage to be created, which will in turn trigger the manifest job and so on.
 
-## Using runCI (recommended)
+## Using runCI
 This method utilizes a runCI pipeline job to give you the same `OUT` capability in CI that several other pipeline job types already have. [(see docs for detailed description)](../../../pipelines/jobs/overview/)
 
 * First, make sure that your enabled project has an associated runCI job.  Today, runCI jobs are created automatically when a project is newly enabled for CI. To create a runCI job for a project enabled before Feb. 18, 2017, click the "Hook" button on the project settings page.  [See here](../../pipelines/jobs/runCI.md) for details about creating and utilizing runCI jobs.
@@ -59,34 +59,3 @@ With this configuration, when you run a build you should see some extra logs tha
 <img src="../../images/pipelines/outConsole.png" alt="Sample job log output for version updating" style="width:800px;vertical-align: middle;display: block;margin-left: auto;margin-right: auto;"/>
 
 When the POST occurs for the new version of the resource, any subsequent jobs that depend on that resource will automatically be triggered.
-
-## Using Event Triggers via notification integrations (deprecated)
-NOTE: This method is not recommended, but will still work until we fully sunset the eventTrigger integration support.  We recommend you use the runCI method listed above to accomplish your scenarios instead.
-
-* Create an API token for your account. To do this, go to your **Account Settings** by clicking on the gear icon in the top navbar. Then click on **API tokens** in the left sidebar menu and create a token. Copy the token since you won't be able to see it again.
-
-* Next, create an account integration of type 'Event Trigger'
-    * While still on **Account Settings**, go to  **Integrations** in the left sidebar menu and then click on **Add Integration**
-    * Click the **Create Integration** button next to **Event Trigger**. In the **Create Event Trigger Integration** tab, complete the settings as shown below. Select the subscription containing your CI project; this will add the account integration to that subscription as a subscription integration. Please make sure you update the `Authorization` textbox in the format `apiToken <token-value>`. The resource name should be the resource that refers to the image you're pushing as part of your CI.
-
-    <br>
-
-<img src="../../images/pipelines/samplePipelineEventTriggerIntegration.png" alt="Shippable Continuous Integration and Delivery" style="width:800px;"/>
-
-* Next, add the following to the shippable.yml for your CI project:
-
-```
-integrations:
-  notifications:
-    - integrationName: triggerDemoPipeline #Replace with name of the integration from subscription settings
-      type: webhook
-      payload:
-        - versionName=$BRANCH.$BUILD_NUMBER  #Replace with the tag of the image you pushed during CI
-      on_success: always
-      on_failure: never
-
-```
-
-And that's it. The next time you run your CI build and push your image, your pipeline will be triggered by your event trigger integration.
-
-<img src="../../images/pipelines/connectingCiPipelines.png" alt="connecting CI with pipelines" style="width:800px;"/>

--- a/sources/tutorials/pipelines/samplePipeline.md
+++ b/sources/tutorials/pipelines/samplePipeline.md
@@ -110,19 +110,30 @@ Now that you have your pipeline up and running, you should connect it to your CI
 
 To do this:
 
-1. Create an API token for your account. To do this, go to your **Account Settings** by clicking on the gear icon in the top navbar. Then click on **API tokens** in the left sidebar menu and create a token. Copy the token since you won't be able to see it again.
+1. add a `runCI` job to your `shippable.jobs.yml` in the `samplePipelinesTest` repo to make the connection.  Do this by opening `shippable.jobs.yml` and uncomment the `runCI` job that you see at the bottom
+```yml
+# Connect CI with dv-img resource
+  - name: samplePipelinesDemo_runCI
+    type: runCI
+    steps:
+      - OUT: dv-img
+# / Connect CI with dv-img resource
 
-1. Next, we will create an account integration of type 'Event Trigger'
-    * Go to  **Integrations** in the left sidebar menu and then click on **Add Integration**
-    * Select **Event Trigger** from the dropdown for **Master Integration** and complete the settings as shown below. Please make sure you update the `Authorization` textbox in the format `apiToken <token-value>`. Also, assign the integration to the Subscription where you forked the repository.
-    <br>
-<img src="/tutorials/images/pipelines/samplePipelineEventTriggerIntegration.png" alt="Shippable Continuous Integration and Delivery" style="width:800px;"/>
-
-1. Next, make the following changes to the shippable.yml at the root of your forked sample application:
-    * Uncomment the `notifications` section
-    * replace `triggerPipelinesDemo` with the name of the **Event Trigger** integration you created. Please use the integration name from your Subscription Settings here.
-
+```
 <img src="../../images/pipelines/samplePipelineConnectCI.png" alt="Shippable Continuous Integration and Delivery" style="width:1000px;"/>
+
+2. Update your `push.sh` script in `samplePipelinesDemo` to look like this:
+```sh
+#!/bin/bash -e
+if [ "$IS_PULL_REQUEST" != true ]; then
+  sudo docker push $IMAGE_NAME:$BRANCH.$BUILD_NUMBER
+  echo "versionName=$BRANCH.$BUILD_NUMBER" >> $JOB_STATE/dv-img.env
+else
+  echo "skipping because it's a PR"
+fi
+
+```
+Now when you push an image, the `dv-img` resource will be udpated with a new tag, triggering your subsequent jobs.
 
 Try pushing a color change to your sample demo by going to the /static/css/app.cat.css file and changing color of .shippableText, and see your pipeline light up! Check your running application to see the new color.
 


### PR DESCRIPTION
#707 

updates the tutorial, and removes the instructions for using eventTriggers from both spots.