### PR TITLE
removing the usingCombinationManifests tutorial link

### DIFF
--- a/sources/pipelines/jobs/manifest.md
+++ b/sources/pipelines/jobs/manifest.md
@@ -81,6 +81,3 @@ jobs:
 
 
 ---
-
-##manifest tutorials
-[Using a combination manifest pattern](../../tutorials/usingCombinationManifests/])


### PR DESCRIPTION
https://github.com/Shippable/docsv2/issues/736

The link it is currently pointing to was removed in this [PR](https://github.com/Shippable/docsv2/pull/552)