### PR TITLE
updates docs to include new scm providers for tags

### DIFF
--- a/sources/legacyFiles/ci_projects.md
+++ b/sources/legacyFiles/ci_projects.md
@@ -102,7 +102,7 @@ In this section, you can enable or disable triggering of builds for your project
 
 - **Pull Requests**: Default value is Enabled. Every pull request initiated on the project in your source control system, triggers a build on Shippable. Click 'Disable' to stop the triggering of builds for this project.
 - **Commits**: Default value is Enabled. Every commit initiated on the project in your source control system, triggers a build on Shippable. Click 'Disable' to stop the triggering of builds for this project.
-- **Tags**: Default value is Disabled. To trigger builds for all git tag push events on the project in your source control system, click 'Enable'. Currently this feature is supported only for GitHub.
+- **Tags**: Default value is Disabled. To trigger builds for all git tag push events on the project in your source control system, click 'Enable'. Currently this feature is supported only for GitHub, Gitlab and Bitbucket.
 - **Releases**: Default value is Disabled. To trigger builds for all GitHub release events on the project in your source control system, click 'Enable'. Currently this feature is supported only for GitHub.
 
 NOTE: The above webhook events, when enabled, trigger builds on Shippable irrespective of the user who initiated the event on the source control system.

--- a/sources/legacyFiles/ci_projects.md
+++ b/sources/legacyFiles/ci_projects.md
@@ -102,7 +102,7 @@ In this section, you can enable or disable triggering of builds for your project
 
 - **Pull Requests**: Default value is Enabled. Every pull request initiated on the project in your source control system, triggers a build on Shippable. Click 'Disable' to stop the triggering of builds for this project.
 - **Commits**: Default value is Enabled. Every commit initiated on the project in your source control system, triggers a build on Shippable. Click 'Disable' to stop the triggering of builds for this project.
-- **Tags**: Default value is Disabled. To trigger builds for all git tag push events on the project in your source control system, click 'Enable'. Currently this feature is supported only for GitHub, Gitlab and Bitbucket.
+- **Tags**: Default value is Disabled. To trigger builds for all git tag push events on the project in your source control system, click 'Enable'. Currently this feature is supported only for GitHub, Gitlab, Bitbucket and BitbucketServer.
 - **Releases**: Default value is Disabled. To trigger builds for all GitHub release events on the project in your source control system, click 'Enable'. Currently this feature is supported only for GitHub.
 
 NOTE: The above webhook events, when enabled, trigger builds on Shippable irrespective of the user who initiated the event on the source control system.

--- a/sources/navigatingUI/projects/settings.md
+++ b/sources/navigatingUI/projects/settings.md
@@ -96,7 +96,7 @@ in your source control system, triggers a build on Shippable. Click 'Disable' to
 stop the triggering of builds for this project.
 - **Tags**: Default value is Disabled. To trigger builds for all git tag push events
 on the project in your source control system, click 'Enable'. Currently this feature
-is supported only for GitHub.
+is supported only for GitHub, Gitlab and Bitbucket.
 - **Releases**: Default value is Disabled. To trigger builds for all GitHub release
 events on the project in your source control system, click 'Enable'. Currently this
 feature is supported only for GitHub.

--- a/sources/navigatingUI/projects/settings.md
+++ b/sources/navigatingUI/projects/settings.md
@@ -96,7 +96,7 @@ in your source control system, triggers a build on Shippable. Click 'Disable' to
 stop the triggering of builds for this project.
 - **Tags**: Default value is Disabled. To trigger builds for all git tag push events
 on the project in your source control system, click 'Enable'. Currently this feature
-is supported only for GitHub, Gitlab and Bitbucket.
+is supported only for GitHub, Gitlab, Bitbucket and BitbucketServer.
 - **Releases**: Default value is Disabled. To trigger builds for all GitHub release
 events on the project in your source control system, click 'Enable'. Currently this
 feature is supported only for GitHub.


### PR DESCRIPTION
https://github.com/Shippable/pm/issues/8000

![image](https://cloud.githubusercontent.com/assets/14016521/24095014/3a9b1728-0d81-11e7-83a5-1b2666ae94f9.png)


I am not able to find out where `sources/legacyFiles/ci_projects.md` renders in UI.